### PR TITLE
Make `runRandomSource` usable

### DIFF
--- a/polysemy-RandomFu/package.yaml
+++ b/polysemy-RandomFu/package.yaml
@@ -65,6 +65,7 @@ tests:
     - hspec-discover  >= 2.0
     dependencies:
     - polysemy-zoo
-    - polysemy-RandomFu 
+    - polysemy-RandomFu
+    - vector >= 0.7 && < 0.13
     - hspec >= 2.0
     - text >= 1.1.0.0 && < 1.3.0.0

--- a/polysemy-RandomFu/polysemy-RandomFu.cabal
+++ b/polysemy-RandomFu/polysemy-RandomFu.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: eae1a0503816a03e0d5218be187818539f2cba48460bc5b150f75b11a2ea2dfb
+-- hash: 021b283239a40ddcbaf797aa27c8a9d851392c7b41b3609a3713d8794cd435b9
 
 name:           polysemy-RandomFu
 version:        0.2.0.0
@@ -70,4 +70,5 @@ test-suite polysemy-RandomFu-test
     , random-fu >=0.2.5.0 && <0.3.0.0
     , random-source >=0.3 && <0.4.0.0
     , text >=1.1.0.0 && <1.3.0.0
+    , vector >=0.7 && <0.13
   default-language: Haskell2010

--- a/polysemy-RandomFu/src/Polysemy/RandomFu.hs
+++ b/polysemy-RandomFu/src/Polysemy/RandomFu.hs
@@ -64,14 +64,16 @@ sampleDist = sampleRVar . R.rvar
 ------------------------------------------------------------------------------
 -- | Run a 'Random' effect using a given 'R.RandomSource'
 runRandomSource
-  :: forall s r a
-   . R.RandomSource (Sem r) s
+  :: forall s m r a
+   . ( R.RandomSource m s
+     , Member (Lift m) r
+     )
   => s
   -> Sem (RandomFu ': r) a
   -> Sem r a
 runRandomSource source = interpret $ \case
-    SampleRVar    rv -> R.runRVar (R.sample rv) source
-    GetRandomPrim pt -> R.runRVar (R.getRandomPrim pt) source
+    SampleRVar    rv -> sendM $ R.runRVar (R.sample rv) source
+    GetRandomPrim pt -> sendM $ R.runRVar (R.getRandomPrim pt) source
 {-# INLINEABLE runRandomSource #-}
 
 ------------------------------------------------------------------------------
@@ -89,11 +91,11 @@ runRandomIO = interpret $ \case
 ------------------------------------------------------------------------------
 -- | Run in 'IO', using the given 'R.PureMT' source, stored in an 'IORef'
 runRandomIOPureMT
-  :: MonadIO (Sem r)
+  :: Member (Lift IO) r
   => R.PureMT
   -> Sem (RandomFu ': r) a
   -> Sem r a
 runRandomIOPureMT source re =
-  liftIO (newIORef source) >>= flip runRandomSource re
+  sendM (newIORef source) >>= flip runRandomSource re
 {-# INLINEABLE runRandomIOPureMT #-}
 

--- a/polysemy-RandomFu/test/RandomFuSpec.hs
+++ b/polysemy-RandomFu/test/RandomFuSpec.hs
@@ -14,6 +14,9 @@ import           Control.Monad.IO.Class         ( liftIO )
 import qualified Data.Random                   as R
 import qualified Data.Random.Source.PureMT     as R
 
+import qualified Data.Random.Source.MWC as MWC
+import qualified Data.Vector as V
+
 getRandomInts :: Member RandomFu r => Int -> Sem r [Int]
 getRandomInts nDraws =
   sampleRVar $ M.replicateM nDraws (R.uniform 0 (100 :: Int))
@@ -55,6 +58,13 @@ spec = describe "RandomFu" $ do
 
         result `shouldBe` [3, 78, 53, 41, 56]
 
+  it
+      "Should produce [95, 40, 24, 49, 64], 5 pseudo-random Ints seeded from the same seed on each test, from an MWC RandomSource."
+    $ do
+      gen <- MWC.initialize (V.fromList [0])
+      result <-
+        runM . runRandomSource gen $ getRandomInts 5
+      result `shouldBe` [95, 40, 24, 49, 64]
 
   it "Should produce two distinct sets of psuedo-random Ints." $ do
     result <- runM . runRandomIO $ randomListsDifferent 5


### PR DESCRIPTION
Previously, using `runRandomSource`'s type required [`RandomSource`](https://hackage.haskell.org/package/random-source-0.3.0.6/docs/Data-Random-Source.html#t:RandomSource) `(Sem r)`, which seems impossible or very hard to implement to me. By changing it to require `Member (Lift m) r` along with `RandomSource m s`, it becomes easily usable, because the Monad `m` the `RandomSource` requires can be lifted to the `Lift` effect.

If there is an easy way to use `runRandomSource` without this change, please let me know.